### PR TITLE
Fix Memory Leak in AVAudioConverter.convert

### DIFF
--- a/RootEncoder/Sources/RootEncoder/encoder/audio/AudioEncoder.swift
+++ b/RootEncoder/Sources/RootEncoder/encoder/audio/AudioEncoder.swift
@@ -133,18 +133,20 @@ public class AudioEncoder {
         var status: AVAudioConverterOutputStatus? = .endOfStream
         
         repeat {
-            status = converter?.convert(to: outputBuffer, error: nil) { inNumberFrames, status in
-                if force {
-                    status.pointee = .haveData
-                    return inputBuffer
-                } else if inNumberFrames <= ringBuffer.counts {
-                    _ = ringBuffer.render(inNumberFrames, ioData: inputBuffer.mutableAudioBufferList)
-                    inputBuffer.frameLength = inNumberFrames
-                    status.pointee = .haveData
-                    return inputBuffer
-                } else {
-                    status.pointee = .noDataNow
-                    return nil
+            autoreleasepool {
+                status = converter?.convert(to: outputBuffer, error: nil) { inNumberFrames, status in
+                    if force {
+                        status.pointee = .haveData
+                        return inputBuffer
+                    } else if inNumberFrames <= ringBuffer.counts {
+                        _ = ringBuffer.render(inNumberFrames, ioData: inputBuffer.mutableAudioBufferList)
+                        inputBuffer.frameLength = inNumberFrames
+                        status.pointee = .haveData
+                        return inputBuffer
+                    } else {
+                        status.pointee = .noDataNow
+                        return nil
+                    }
                 }
             }
             switch status {


### PR DESCRIPTION
When audio streaming is enabled, the app was allocating excessive memory. 

#### Issue:
AVAudioConverter.convert was not freeing allocated memory, leading to a memory leak.

#### Solution:
This commit resolves the issue by wrapping the conversion process in an `autoreleasepool`. 

Based on this solution: https://stackoverflow.com/questions/75943924/avaudioconverter-buffers-are-over-retained-in-a-dispatchqueue-concurrentperform

#### Before:
<img width="996" alt="Before" src="https://github.com/user-attachments/assets/8ae8ca91-1ff0-4771-84b2-d2af25773967">


#### After:
<img width="991" alt="After" src="https://github.com/user-attachments/assets/e2639aad-e04f-405a-8546-4738976c1fcb">