### PR TITLE
Remove await warning

### DIFF
--- a/RootEncoder/Sources/RootEncoder/rtmp/amf/v0/AmfData.swift
+++ b/RootEncoder/Sources/RootEncoder/rtmp/amf/v0/AmfData.swift
@@ -55,7 +55,7 @@ public class AmfData: AmfActions {
     }
 
     public func writeHeader(socket: Socket) async throws {
-        try await socket.write(buffer: writeHeader())
+        try socket.write(buffer: writeHeader())
     }
 
     public func readBody(buffer: inout [UInt8]) throws {


### PR DESCRIPTION
`Socket.write(buffer: [UInt8])` is not async function and calling it with `await` show warning:

`No 'async' operations occur within 'await' expression`