### PR TITLE
 Implemented CameraManager Access, AVCaptureSession Configuration, Preview Layer Removal, and Custom Resolutions

### DIFF
--- a/RootEncoder/Sources/RootEncoder/encoder/input/video/CameraManager.swift
+++ b/RootEncoder/Sources/RootEncoder/encoder/input/video/CameraManager.swift
@@ -171,6 +171,7 @@ public class CameraManager: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
         }
     }
     
+    @discardableResult
     public func configureCaptureSession(with configuration: @escaping (AVCaptureSession) -> Bool) -> Bool {
         if let session {
             return configuration(session)

--- a/RootEncoder/Sources/RootEncoder/encoder/input/video/CameraManager.swift
+++ b/RootEncoder/Sources/RootEncoder/encoder/input/video/CameraManager.swift
@@ -173,12 +173,8 @@ public class CameraManager: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
         }
     }
     
-    @discardableResult
-    public func configureCaptureSession(with configuration: (AVCaptureSession) -> Bool) -> Bool {
-        if let session {
-            return configuration(session)
-        }
-        return false
+    public func getCaptureSession() -> AVCaptureSession? {
+        session
     }
     
 }

--- a/RootEncoder/Sources/RootEncoder/encoder/input/video/CameraManager.swift
+++ b/RootEncoder/Sources/RootEncoder/encoder/input/video/CameraManager.swift
@@ -170,4 +170,12 @@ public class CameraManager: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
             return .landscapeLeft
         }
     }
+    
+    public func configureCaptureSession(with configuration: @escaping (AVCaptureSession) -> Bool) -> Bool {
+        if let session {
+            return configuration(session)
+        }
+        return false
+    }
+    
 }

--- a/RootEncoder/Sources/RootEncoder/encoder/input/video/CameraManager.swift
+++ b/RootEncoder/Sources/RootEncoder/encoder/input/video/CameraManager.swift
@@ -39,6 +39,8 @@ public class CameraManager: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
     }
 
     public func stop() {
+        prevLayer?.removeFromSuperlayer()
+        prevLayer = nil
         session?.stopRunning()
         session?.removeOutput(output!)
         session?.removeInput(input!)

--- a/RootEncoder/Sources/RootEncoder/encoder/input/video/CameraManager.swift
+++ b/RootEncoder/Sources/RootEncoder/encoder/input/video/CameraManager.swift
@@ -172,7 +172,7 @@ public class CameraManager: NSObject, AVCaptureVideoDataOutputSampleBufferDelega
     }
     
     @discardableResult
-    public func configureCaptureSession(with configuration: @escaping (AVCaptureSession) -> Bool) -> Bool {
+    public func configureCaptureSession(with configuration: (AVCaptureSession) -> Bool) -> Bool {
         if let session {
             return configuration(session)
         }

--- a/RootEncoder/Sources/RootEncoder/encoder/utils/CameraHelper.swift
+++ b/RootEncoder/Sources/RootEncoder/encoder/utils/CameraHelper.swift
@@ -33,13 +33,14 @@ public class CameraHelper {
         case FRONT
     }
 
-    public enum Resolution {
+    public enum Resolution: Equatable {
         case cif352x288
         case vga640x480
         case hd1280x720
         case fhd1920x1080
         case fhd1920x1440
         case uhd3840x2160
+        case custom(width: Int, height: Int, preset: AVCaptureSession.Preset)
 
         public var width: Int {
             switch self {
@@ -55,6 +56,8 @@ public class CameraHelper {
                 return 1920
             case .uhd3840x2160:
                 return 3840
+            case let .custom(width, _, _):
+                return width
             }
         }
 
@@ -72,6 +75,8 @@ public class CameraHelper {
                 return 1440
             case .uhd3840x2160:
                 return 2160
+            case let .custom(_, height, _):
+                return height
             }
         }
 
@@ -89,6 +94,8 @@ public class CameraHelper {
                 return .hd1920x1080
             case .uhd3840x2160:
                 return .hd4K3840x2160
+            case let .custom(_, _, preset):
+                return preset
             }
         }
     }

--- a/RootEncoder/Sources/RootEncoder/library/base/CameraBase.swift
+++ b/RootEncoder/Sources/RootEncoder/library/base/CameraBase.swift
@@ -229,4 +229,9 @@ public class CameraBase: GetMicrophoneData, GetCameraData, GetAudioData, GetVide
     public func onVideoInfo(sps: Array<UInt8>, pps: Array<UInt8>, vps: Array<UInt8>?) {
         onVideoInfoImp(sps: sps, pps: pps, vps: vps)
     }
+    
+    public func getCameraManager() -> CameraManager {
+        cameraManager
+    }
+    
 }


### PR DESCRIPTION
Hello,

I’ve implemented a few features that are required for our project and may be useful for others:

### 1. Access to CameraManager
- **Summary:** Added a getter to access `CameraManager` via `CameraBase`.
- **Reason:** This access is necessary for configuring the `AVCaptureSession` (see Item 2).

### 2. Access to AVCaptureSession
- **Summary:** Provided access to the `AVCaptureSession` for configuration purposes.
- **Usage:** For example, adding `AVCaptureMetadataOutput` to the session to detect faces.
- **Implementation:** Added a new method `getCaptureSession()` in `CameraManager`.

```swift
guard let captureSession = rtspCamera.getCameraManager().getCaptureSession() else {
    return
}

let metadataOutput = AVCaptureMetadataOutput()

if captureSession.canAddOutput(metadataOutput) {
    captureSession.beginConfiguration()
    captureSession.addOutput(metadataOutput)
    metadataOutput.setMetadataObjectsDelegate(self, queue: .main)
    metadataOutput.metadataObjectTypes = [.face]
    captureSession.commitConfiguration()
    self.metadataOutput = metadataOutput
}
```

- **Note:** If accessing `CameraManager` directly isn't the best approach, I can move the `getCaptureSession()` method to `CameraBase`. However, since `CameraManager` already has a public access modifier, I believe this solution is acceptable.

### 3. Removing Preview Layers
- **Summary:** Fixed an issue where multiple instances of `AVCaptureVideoPreviewLayer` were created but not removed, leading to visual artifacts on device rotation.
- **Implementation:** Added `removeLayerFromSuperlayer` to `CameraManager.stop()`.

### 4. Custom Resolution
- **Summary:** The existing enum cases in `CameraManager.Resolution` were insufficient for some use cases, such as selecting a `640x360` SD resolution with a `16:9` aspect ratio.
- **Implementation:** Added a new case `custom(width: Int, height: Int, preset: AVCaptureSession.Preset)` to allow developers to define custom resolutions.
- **Example Usage:**
  
```swift
static var sd640x360: CameraHelper.Resolution {
    .custom(width: 640, height: 360, preset: .high)
}
```

### P.S.
I noticed that in some places, such as `RtspCamera.getStreamClient`, you use function getters. Wouldn’t it be more concise to use `private(set)`?

```swift
public private(set) var streamClient: RtspStreamClient!
```

Following your pattern, I implemented the getters for `CameraManager` and `CaptureSession`. 