### PR TITLE
Fix memory leaks in Socket

### DIFF
--- a/RootEncoder/Sources/RootEncoder/common/Socket.swift
+++ b/RootEncoder/Sources/RootEncoder/common/Socket.swift
@@ -105,7 +105,7 @@ public class Socket: NSObject, StreamDelegate {
         }
         let data = outputBuffer
         if !data.isEmpty && data.count > 0 {
-            outputBuffer.removeFirst(data.count)
+            outputBuffer.removeSubrange(0..<data.count)
             connection?.send(content: data, completion: .contentProcessed { error in
                 if error != nil {
                     self.disconnect(error: "write error")


### PR DESCRIPTION
### Context

When streaming, the use of `outputBuffer.removeFirst(data.count)` does not effectively free memory, which can lead to inefficiencies.

### Change

Based on advice from an [Apple Engineer](https://developer.apple.com/forums/thread/659261?answerId=630923022#630923022), I replaced `removeFirst` with `removeSubrange` to optimize memory usage.

### Before

<img width="1053" alt="Screenshot 2024-08-19 at 16 06 12" src="https://github.com/user-attachments/assets/9a267fce-7aae-4a01-aefe-a6a7d082b9c4">

### After

<img width="1049" alt="Screenshot 2024-08-19 at 16 08 06" src="https://github.com/user-attachments/assets/aa0c28d7-babb-40bc-a5ee-627b437957e6">